### PR TITLE
News Section Browser Launch

### DIFF
--- a/PsycheApp/app/src/main/java/asu/whirlpool/psychewhirlpool/MainActivity.java
+++ b/PsycheApp/app/src/main/java/asu/whirlpool/psychewhirlpool/MainActivity.java
@@ -26,6 +26,8 @@ public class MainActivity extends AppCompatActivity
     private BottomNavigationView navigation;
     private ConstraintLayout mHelpBox, mButtonsBox;
 
+    private final String NEWS_URI = "https://psyche.asu.edu/category/news/";
+
     private BottomNavigationView.OnNavigationItemSelectedListener mOnNavigationItemSelectedListener
             = new BottomNavigationView.OnNavigationItemSelectedListener()
     {
@@ -103,6 +105,13 @@ public class MainActivity extends AppCompatActivity
     {
         Intent intent = new Intent(this, FactsActivity.class);
         startActivity(intent);
+    }
+
+    public void displayNews(View view)
+    {
+        Uri newsUrl = Uri.parse(NEWS_URI);
+        Intent launchBrowser = new Intent(Intent.ACTION_VIEW, newsUrl);
+        startActivity(launchBrowser);
     }
 
     /**

--- a/PsycheApp/app/src/main/res/layout/activity_main.xml
+++ b/PsycheApp/app/src/main/res/layout/activity_main.xml
@@ -254,7 +254,7 @@
             android:layout_marginTop="2dp"
             android:background="@android:color/transparent"
             android:elevation="16dp"
-            android:onClick="displayFacts"
+            android:onClick="displayNews"
             android:paddingTop="@dimen/tw__composer_close_size"
             android:text="@string/button_home_news"
             android:textAlignment="center"


### PR DESCRIPTION
The Psyche Team's primary news is hosted on an ASU website, which to my
knowledge has no public API I can access.

That leaves three possibilities:

1. ASU has some private API I can access (Highly Unlikely, especially
this close to the deadline)
2. The Psyche Team is going to keep using the Medium Blog (In which case
I can try to implement another API, but this may also be difficult due
to time constraints AND contradicts their plans)
3.  I hard-code all the links and images (Which is a waste of time and
useless for a section that needs to be updated frequently).

For now, I'll have the News button redirect to the ASU Psyche news page
in-browser like the NASA button.